### PR TITLE
Fix compiler errors on new jda version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ ext {
     javaWebSocketVersion        = '1.3.8'
     slf4jVersion                = '1.7.25'
     jsonOrgVersion              = '20180130'
-    jdaVersion                  = '3.6.0_367'
+    jdaVersion                  = '3.7.1_400'
     spotbugsAnnotationsVersion  = '3.1.3'
     prometheusVersion           = '0.4.0'
 

--- a/src/main/java/lavalink/client/io/jda/VoiceServerUpdateInterceptor.java
+++ b/src/main/java/lavalink/client/io/jda/VoiceServerUpdateInterceptor.java
@@ -45,11 +45,11 @@ public class VoiceServerUpdateInterceptor extends SocketHandler {
         log.debug(content.toString());
         long idLong = content.getLong("guild_id");
 
-        if (api.getGuildLock().isLocked(idLong))
+        if (getJDA().getGuildLock().isLocked(idLong))
             return idLong;
 
         // Get session
-        Guild guild = api.getGuildMap().get(idLong);
+        Guild guild = getJDA().getGuildMap().get(idLong);
         if (guild == null)
             throw new IllegalArgumentException("Attempted to start audio connection with Guild that doesn't exist! JSON: " + content);
 

--- a/src/main/java/lavalink/client/io/jda/VoiceStateUpdateInterceptor.java
+++ b/src/main/java/lavalink/client/io/jda/VoiceStateUpdateInterceptor.java
@@ -20,14 +20,14 @@ public class VoiceStateUpdateInterceptor extends VoiceStateUpdateHandler {
     @Override
     protected Long handleInternally(JSONObject content) {
         final Long guildId = content.has("guild_id") ? content.getLong("guild_id") : null;
-        if (guildId != null && api.getGuildLock().isLocked(guildId))
+        if (guildId != null && getJDA().getGuildLock().isLocked(guildId))
             return guildId;
         if (guildId == null)
             return super.handleInternally(content);
 
         final long userId = content.getLong("user_id");
         final Long channelId = !content.isNull("channel_id") ? content.getLong("channel_id") : null;
-        Guild guild = api.getGuildById(guildId);
+        Guild guild = getJDA().getGuildById(guildId);
         if (guild == null) return super.handleInternally(content);
 
         Member member = guild.getMemberById(userId);
@@ -49,7 +49,7 @@ public class VoiceStateUpdateInterceptor extends VoiceStateUpdateHandler {
         }
 
         if (link.getState() == Link.State.CONNECTED) {
-            api.getClient().updateAudioConnection(guildId, channel);
+            getJDA().getClient().updateAudioConnection(guildId, channel);
         }
 
         return super.handleInternally(content);


### PR DESCRIPTION
We now use getJDA() in handlers instead.