### PR TITLE
Add user data to tracks from WS

### DIFF
--- a/src/main/java/lavalink/client/LavalinkUtil.java
+++ b/src/main/java/lavalink/client/LavalinkUtil.java
@@ -33,6 +33,7 @@ import com.sedmelluq.discord.lavaplayer.source.youtube.YoutubeAudioSourceManager
 import com.sedmelluq.discord.lavaplayer.tools.io.MessageInput;
 import com.sedmelluq.discord.lavaplayer.tools.io.MessageOutput;
 import com.sedmelluq.discord.lavaplayer.track.AudioTrack;
+import lavalink.client.player.LavalinkPlayer;
 import org.java_websocket.util.Base64;
 
 import java.io.ByteArrayInputStream;
@@ -53,6 +54,24 @@ public class LavalinkUtil {
         PLAYER_MANAGER.registerSourceManager(new TwitchStreamAudioSourceManager());
         PLAYER_MANAGER.registerSourceManager(new VimeoAudioSourceManager());
         PLAYER_MANAGER.registerSourceManager(new HttpAudioSourceManager());
+    }
+
+    /**
+     *
+     * @param player the lavalink player that holds the track with data
+     * @param message the Base64 audio track
+     * @return the AudioTrack with the user data stored in the player
+     * @throws IOException if there is an IO problem
+     */
+    public static AudioTrack toAudioTrackWithData(LavalinkPlayer player, String message) throws IOException{
+        AudioTrack storedTrack = player.getPlayingTrack();
+        AudioTrack messageTrack = toAudioTrack(message);
+
+        if (storedTrack != null && storedTrack.getUserData() != null) {
+            messageTrack.setUserData(storedTrack.getUserData());
+        }
+
+        return messageTrack;
     }
 
     /**

--- a/src/main/java/lavalink/client/io/LavalinkSocket.java
+++ b/src/main/java/lavalink/client/io/LavalinkSocket.java
@@ -120,7 +120,7 @@ public class LavalinkSocket extends ReusableWebSocket {
         switch (json.getString("type")) {
             case "TrackEndEvent":
                 event = new TrackEndEvent(player,
-                        LavalinkUtil.toAudioTrack(json.getString("track")),
+                        LavalinkUtil.toAudioTrackWithData(player, json.getString("track")),
                         AudioTrackEndReason.valueOf(json.getString("reason"))
                 );
                 break;
@@ -138,12 +138,12 @@ public class LavalinkSocket extends ReusableWebSocket {
                 }
 
                 event = new TrackExceptionEvent(player,
-                        LavalinkUtil.toAudioTrack(json.getString("track")), ex
+                        LavalinkUtil.toAudioTrackWithData(player, json.getString("track")), ex
                 );
                 break;
             case "TrackStuckEvent":
                 event = new TrackStuckEvent(player,
-                        LavalinkUtil.toAudioTrack(json.getString("track")),
+                        LavalinkUtil.toAudioTrackWithData(player, json.getString("track")),
                         json.getLong("thresholdMs")
                 );
                 break;


### PR DESCRIPTION
Currently, tracks that come back from the lavalink server have no user data attached to them.
Because we have the currently playing track in the LavalinkPlayer class we can get the user data from that before the end event is fired.