### PR TITLE
Add getter for player_manager in LavalinkUtil

### DIFF
--- a/src/main/java/lavalink/client/LavalinkUtil.java
+++ b/src/main/java/lavalink/client/LavalinkUtil.java
@@ -120,4 +120,8 @@ public class LavalinkUtil {
         return (int) ((Long.parseLong(snowflake) >> 22) % numShards);
     }
 
+    public static AudioPlayerManager getPlayerManager() {
+        return PLAYER_MANAGER;
+    }
+
 }


### PR DESCRIPTION
In case of custom source managers, it is required to add them to the lavalink player-manager as well due to the decoding and encoding of messages
it also looks a bit better than 
```java
try {
    final Class<LavalinkUtil> klass = LavalinkUtil.class;
    final Field playerManagerField = klass.getDeclaredField("PLAYER_MANAGER");
    playerManagerField.setAccessible(true);
    final AudioPlayerManager manager = (AudioPlayerManager) playerManagerField.get(klass);

    manager.registerSourceManager(.....);
}
catch (NoSuchFieldException | IllegalAccessException e) {
    e.printStackTrace();
}
```